### PR TITLE
Fix SPDX repository of plain text licenses

### DIFF
--- a/site/content/practices/2.0.md
+++ b/site/content/practices/2.0.md
@@ -28,7 +28,7 @@ never change any license texts even if they are very similar to existing ones.
 
 The easiest way to make sure that you provide an unchanged license is by copying
 it verbatim from [this repository of
-licenses](https://github.com/spdx/license-list) maintained by the SPDX
+licenses](https://github.com/spdx/license-list-data/tree/master/text) maintained by the SPDX
 Workgroup.  The SPDX Workgroup maintains a [list of commonly-used
 licenses][spdx-licenses].  Each license has a shorthand name (called an SPDX
 identifier) that can be used to uniquely reference each license.  For instance,


### PR DESCRIPTION
The previous repository was deprecated and all work is done in XML now:
<https://github.com/spdx/license-list-XML/>

From the XML sources then other formats are being automatically generated here:
<https://github.com/spdx/license-list-data/>

Amongst other formats (JSON, RDFa, HTML, etc.), there is also plain text:
https://github.com/spdx/license-list-data/tree/master/text