### PR TITLE
Fix copyright statements

### DIFF
--- a/site/content/practices/2.0.md
+++ b/site/content/practices/2.0.md
@@ -173,6 +173,17 @@ an organisation rather than the author. For example:
   */
 ~~~~~~~
 
+Alternatively, if you cannot use the Unicode copyright sign `©`, you may use 
+"Copyright" as a full word instead. For example:
+
+~~~~~~~
+ /*
+  * Copyright 2017 Alice Commit <alice@example.com>
+  * 
+  * SPDX-License-Identifier: GPL-2.0
+  */
+~~~~~~~
+
 You should include information about your project's practices in the README or
 similar file.  This could be as simple as linking to these practices.
 
@@ -248,6 +259,7 @@ An appropriate header in this case would be:
 > ## Keep in mind
 > 
 > * Use a consistent style of your headers throughout the project.
+    Preferably use the form `© Alice Committer <alice@example.com`.
 > * Don't remove existing headers, but only add to them.
 > * Do consider using version control systems to keep a record of copyright holders.
 > * Do keep your version control system public if you use it.

--- a/site/content/practices/2.0.md
+++ b/site/content/practices/2.0.md
@@ -86,6 +86,10 @@ copy of this software and associated documentation files (the "Software"),
  etc...
 ```
 
+> **Note:** Even though the copyright statement in the above example is not in 
+> accordance to the REUSE spec, we keep the same form as it is in the canonical 
+> license template, so tools identify it as the same MIT license.
+
 While the identifier should be a license in the SPDX license list, it should be
 noted that the license text itself may not necessarily be released under that
 license, nor does the tag claim that.

--- a/site/content/practices/2.0.md
+++ b/site/content/practices/2.0.md
@@ -161,9 +161,9 @@ an organisation rather than the author. For example:
 
 ~~~~~~~
  /*
-  * Copyright (c) 2017 Alice Commit <alice@example.com>
-  * Copyright (c) 2009-2016 Bob Denver <bob@example.com>
-  * Copyright (c) 2007 Company Example <charlie@example.com>
+  * © 2017 Alice Commit <alice@example.com>
+  * © 2009-2016 Bob Denver <bob@example.com>
+  * © 2007 Company Example <charlie@example.com>
   * 
   * SPDX-License-Identifier: GPL-2.0
   */

--- a/site/content/practices/2.0.md
+++ b/site/content/practices/2.0.md
@@ -28,7 +28,7 @@ never change any license texts even if they are very similar to existing ones.
 
 The easiest way to make sure that you provide an unchanged license is by copying
 it verbatim from [this repository of
-licenses](https://github.com/spdx/license-list) maintained by the SPDX
+licenses](https://github.com/spdx/license-list-data/tree/master/text) maintained by the SPDX
 Workgroup.  The SPDX Workgroup maintains a [list of commonly-used
 licenses][spdx-licenses].  Each license has a shorthand name (called an SPDX
 identifier) that can be used to uniquely reference each license.  For instance,


### PR DESCRIPTION
Fixes https://github.com/reusesoftware/reuse/issues/5

But the `reuse` tool and its documentation would need to reflect it as well.